### PR TITLE
target edge-light runtime

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@vercel/edge-config": "0.1.4"
+  },
+  "changesets": []
+}

--- a/.changeset/strange-cougars-marry.md
+++ b/.changeset/strange-cougars-marry.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+explicitly target edge-light runtime environment

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    ".": {
-      "import": {
-        "node": "./dist/index.node.js",
-        "default": "./dist/index.edge.js"
-      },
-      "require": {
-        "node": "./dist/index.node.cjs",
-        "default": "./dist/index.edge.cjs"
-      }
+    "import": {
+      "edge-light": "./dist/index.edge.js",
+      "node": "./dist/index.node.js",
+      "default": "./dist/index.edge.js"
+    },
+    "require": {
+      "edge-light": "./dist/index.edge.cjs",
+      "node": "./dist/index.node.cjs",
+      "default": "./dist/index.edge.cjs"
     }
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Next.js supports the `edge-light` runtime as a target in the conditional exports since https://github.com/vercel/next.js/pull/45188.

https://runtime-keys.proposal.wintercg.org/

This PR explicitly targets the `edge-light` runtime for our Edge Config usage there.