### PR TITLE
Accept interfaces as generic type

### DIFF
--- a/.changeset/fifty-parrots-clean.md
+++ b/.changeset/fifty-parrots-clean.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+accept interfaces as generic types of get<T> and getAll<T>

--- a/src/index.edge.ts
+++ b/src/index.edge.ts
@@ -35,9 +35,7 @@ export function createClient(
   const headers = { Authorization: `Bearer ${connection.token}` };
 
   return {
-    async get<T extends EdgeConfigValue = EdgeConfigValue>(
-      key: string,
-    ): Promise<T | undefined> {
+    async get<T = EdgeConfigValue>(key: string): Promise<T | undefined> {
       assertIsKey(key);
       return fetchWithCachedResponse(`${url}/item/${key}?version=${version}`, {
         headers: new Headers(headers),
@@ -88,9 +86,7 @@ export function createClient(
         },
       );
     },
-    async getAll<T extends EdgeConfigItems = EdgeConfigItems>(
-      keys?: (keyof T)[],
-    ): Promise<T> {
+    async getAll<T = EdgeConfigItems>(keys?: (keyof T)[]): Promise<T> {
       if (Array.isArray(keys)) assertIsKeys(keys);
 
       const search = Array.isArray(keys)

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -61,9 +61,7 @@ export function createClient(
   const headers = { Authorization: `Bearer ${connection.token}` };
 
   return {
-    async get<T extends EdgeConfigValue = EdgeConfigValue>(
-      key: string,
-    ): Promise<T | undefined> {
+    async get<T = EdgeConfigValue>(key: string): Promise<T | undefined> {
       const localEdgeConfig = await getFileSystemEdgeConfig(connection);
       if (localEdgeConfig) {
         assertIsKey(key);
@@ -131,9 +129,7 @@ export function createClient(
         },
       );
     },
-    async getAll<T extends EdgeConfigItems = EdgeConfigItems>(
-      keys?: (keyof T)[],
-    ): Promise<T> {
+    async getAll<T = EdgeConfigItems>(keys?: (keyof T)[]): Promise<T> {
       const localEdgeConfig = await getFileSystemEdgeConfig(connection);
 
       if (localEdgeConfig) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,12 +7,8 @@ export interface EmbeddedEdgeConfig {
  * Edge Config Client
  */
 export interface EdgeConfigClient {
-  get: <T extends EdgeConfigValue = EdgeConfigValue>(
-    key: string,
-  ) => Promise<T | undefined>;
-  getAll: <T extends EdgeConfigItems = EdgeConfigItems>(
-    keys?: (keyof T)[],
-  ) => Promise<T>;
+  get: <T = EdgeConfigValue>(key: string) => Promise<T | undefined>;
+  getAll: <T = EdgeConfigItems>(keys?: (keyof T)[]) => Promise<T>;
   has: (key: string) => Promise<boolean>;
   digest: () => Promise<string>;
 }


### PR DESCRIPTION
It was previously not possible to use an interface as the value of an Edge Config item when calling `get` or `getAll`:

```ts
import {get, EdgeConfigValue } from "@vercel/edge-config"

export interface SomeValue {
  active: boolean
}

const value = await get<SomeValue>("")
```

This would lead to

```
Type 'SomeValue' does not satisfy the constraint 'EdgeConfigValue'.
  Type 'SomeValue' is not assignable to type '{ [x: string]: EdgeConfigValue; }'.
    Index signature for type 'string' is missing in type 'SomeValue'.(2344)
```

This PR loosens the generic. It no longer needs to extend/satisfy `EdgeConfigValue`. This makes the SDK less strict, but at least we are not getting in the way of potentially valid usage.

This PR undoes some of the progress made in https://github.com/vercel/edge-config/pull/67, as it overreached slightly and ruled out valid usage.