### PR TITLE
read body to avoid memory leaks

### DIFF
--- a/.changeset/cyan-ducks-beg.md
+++ b/.changeset/cyan-ducks-beg.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+read body to avoid memory leaks


### PR DESCRIPTION
undici fetch and node-fetch maintain the connection until the body is read, causing a memory leak if the body is not read[^1][^2].

In this Pull Request, if a 304 is returned or an error is returned, a meaningless res.arrayBuffer (slow because res.json and res.text are parsed together) is executed to read the body.

[^1]: https://github.com/nodejs/undici/blob/v5.21.2/README.md#garbage-collection
[^2]: node-fetch/node-fetch#83